### PR TITLE
update installation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 ------------
 
 ```bash
-$ pip install git+https://github.com/quackenbush/APC
+$ pip install git+https://github.com/scls19fr/APC
 ```
 
 or


### PR DESCRIPTION
The URL in the installation instructions is incorrect and pip errors out with the following:

```$ pip install git+https://github.com/quackenbush/APC
Collecting git+https://github.com/quackenbush/APC
  Cloning https://github.com/quackenbush/APC to /tmp/pip-2snx5apg-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.6/tokenize.py", line 452, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-2snx5apg-build/setup.py'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-2snx5apg-build/
```
