### PR TITLE
Fix issue #9: add second pattern-matching for outlet parsing

### DIFF
--- a/apc/cli_apc.py
+++ b/apc/cli_apc.py
@@ -49,7 +49,7 @@ def main():
 
     try:
         apc = APC(args.host, args.user, args.password, args.verbose, args.quiet, args.cli)
-    except pexpect.TIMEOUT as e:
+    except pexpect.TIMEOUT:
         raise SystemExit('ERROR: Timeout connecting to APC')
 
     args.delay = int(args.delay)

--- a/apc/outlet.py
+++ b/apc/outlet.py
@@ -2,9 +2,9 @@
 
 from collections import OrderedDict
 import re
-APC_OUTLET_STATUS_PATTERN = re.compile('(OFF|ON)(\*?)')
-APC_OUTLET_ROW_PATTERN = re.compile('Outlet (\d) (.*) (OFF\*?|ON\*?)')
-APC_OUTLET_ROW_PATTERN2 = re.compile('(\d)- (.*) (OFF\*?|ON\*?)')
+APC_OUTLET_STATUS_PATTERN = re.compile(r'(OFF|ON)(\*?)')
+APC_OUTLET_ROW_PATTERN = re.compile(r'Outlet (\d) (.*) (OFF\*?|ON\*?)')
+APC_OUTLET_ROW_PATTERN2 = re.compile(r'(\d)- (.*) (OFF\*?|ON\*?)')
 
 
 class OutletStatusParseException(Exception):

--- a/apc/outlet.py
+++ b/apc/outlet.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import re
 APC_OUTLET_STATUS_PATTERN = re.compile('(OFF|ON)(\*?)')
 APC_OUTLET_ROW_PATTERN = re.compile('Outlet (\d) (.*) (OFF\*?|ON\*?)')
+APC_OUTLET_ROW_PATTERN2 = re.compile('(\d)- (.*) (OFF\*?|ON\*?)')
 
 
 class OutletStatusParseException(Exception):
@@ -63,7 +64,17 @@ class Outlet:
 
     @classmethod
     def parse(cls, s):
-        match = APC_OUTLET_ROW_PATTERN.search(s)
+        # Two forms of rows can be parsed, either:
+        # 1- OUTLETNAME    ON"
+        # or
+        # Outlet 1 OUTLETNAME    ON"
+
+        # try first form, without the 3 first characters
+        match = APC_OUTLET_ROW_PATTERN.search(s[3:])
+        # if fails, try second
+        if not match:
+            match = APC_OUTLET_ROW_PATTERN2.search(s)
+        # fail if neither patterns match
         if not match:
             raise OutletParseException('Could not parse APC outlet status')
         s_id, s_name, s_status = match.groups()

--- a/apc/utility.py
+++ b/apc/utility.py
@@ -20,7 +20,7 @@ APC_ESCAPE = '\033'
 APC_YES    = 'YES'
 APC_LOGOUT = '4'
 
-APC_VERSION_PATTERN = re.compile(' v(\d+\.\d+\.\d+)')
+APC_VERSION_PATTERN = re.compile(r' v(\d+\.\d+\.\d+)')
 
 APC_DEFAULT_HOST     = os.environ.get('APC_HOST',     '192.168.1.2')
 APC_DEFAULT_USER     = os.environ.get('APC_USER',     'apc')

--- a/apc/utility.py
+++ b/apc/utility.py
@@ -338,8 +338,7 @@ class APC3(AbstractAPC):
         rows = s.split("\n")
         lst_outlets = []
         for row in rows[:-1]:
-            row = row.strip()[3:]
-            ol = Outlet.parse(row)
+            ol = Outlet.parse(row.strip())
             lst_outlets.append(ol)
         ol_collection = Outlets(lst_outlets)
         return ol_collection

--- a/tests/test_outlet.py
+++ b/tests/test_outlet.py
@@ -55,19 +55,26 @@ def test_outlet_contructor():
     assert str(ol) == 'Outlet 2 AAAAAAAAAAAAAAA OFF*'  # display name with only 15 characters
 
 def test_outlet_parse():
-    row = 'Outlet 2 MyServer#2      ON*'
+    row = '2- Outlet 2 MyServer#2      ON*'
     ol = Outlet.parse(row)
     assert ol.id == 2
     assert ol.name == 'MyServer#2'
     assert str(ol.status) == 'ON*'
-    assert str(ol) == row
+    assert str(ol) == "Outlet 2 MyServer#2      ON*"
 
-    row = 'Outlet 2 AAAAAAAAAAAAA   OFF*'
+    row = '2- Outlet 2 AAAAAAAAAAAAA   OFF*'
     ol = Outlet.parse(row)
     assert ol.id == 2
     assert ol.name == 'AAAAAAAAAAAAA'
     assert str(ol.status) == 'OFF*'
-    assert str(ol) == row
+    assert str(ol) == "Outlet 2 AAAAAAAAAAAAA   OFF*"
+
+    row = '2- AAAAAAAAAAAAA   OFF*'
+    ol = Outlet.parse(row)
+    assert ol.id == 2
+    assert ol.name == 'AAAAAAAAAAAAA'
+    assert str(ol.status) == 'OFF*'
+    assert str(ol) == "Outlet 2 AAAAAAAAAAAAA   OFF*"
 
     with pytest.raises(OutletParseException):
         row = 'Xutlet 2 AAAAAAAAAAAAAAA OFF*'  # this is not an allowed status an exception should be raised


### PR DESCRIPTION
It seems that APC versions can differ in their output, this PR handles two different forms of outlet printing